### PR TITLE
Fixed debugging message

### DIFF
--- a/flancy.psm1
+++ b/flancy.psm1
@@ -413,13 +413,21 @@ namespace Flancy {
         function Unwind-Exception {
             Param($Exception)
 
-            if($Exception.InnerException) {
-                $Exception.InnerException.PsObject.Properties | Select-Object -Property Name, Value
+            Write-Error -Exception $Exception
+            $Exception.PsObject.Properties |
+                Select-Object -Property Name, Value |
+                    ForEach-Object {
+                        $_.Name, "$($_.Value)", [System.Environment]::NewLine | Write-Verbose 
+                    }
+
+            if($Exception.InnerException)
+            {
                 Unwind-Exception $Exception.InnerException
             }
         }
 
         Unwind-Exception $_.Exception.InnerException
+        throw "Can't create Flancy! Examine exceptions above or run 'New-Flancy' with '-Verbose' switch to get more details."
     }
     try {
         $flancy.start()


### PR DESCRIPTION
! First exception wasn't printed - fixed
- Exceptions  are now printed with Write-Error
- Full debug log printed only with -Verbose switch
- Throw last exception with 'throw' - we can't create new flancy anyway
#32
#33
